### PR TITLE
Avoid computing model initialization time

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -137,6 +137,7 @@ def main():
     if args.quantize:
         model = quantize(model, weight_bit_width=8, backend="torch")
     model.cuda()
+    torch.cuda.synchronize()
     
     with open(args.prompt_file, "r") as f:
         prompt = f.readlines()


### PR DESCRIPTION
初始化cuda模型时涉及到memcpy h2d操作，这个是异步执行的，然后这个脚本是要统计处理token的时间，所以需要在model.to("cuda")之后同步一下。不然统计时间也会把model.to("cuda")以及model.half()等初始化操作的时间也计算进去，因为[在计时之前](https://github.com/THUDM/CodeGeeX/blob/main/tests/test_inference.py#L154)没有其它的同步操作了。