### PR TITLE
避免quantization在缺少oneflow模块的时候出错.

### DIFF
--- a/codegeex/quantization/__init__.py
+++ b/codegeex/quantization/__init__.py
@@ -1,3 +1,6 @@
 from .quantize import quantize
-from .quantize_oneflow import quantize_oneflow
-from .quantize_oneflow import QuantizedLinear
+try:
+    from .quantize_oneflow import quantize_oneflow
+    from .quantize_oneflow import QuantizedLinear
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
解决 #127 问题，直接忽略oneflow不存在的错误。

后续可以考虑细化逻辑，判断oneflow是否为强依赖.