### PR TITLE
Update tar instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ aria2c -x 16 -s 16 -j 4 --continue=true -i urls.txt
 ```
 Run the following command to get the full model weights:
 ```bash
-cat codegeex_13b.tar.gz.* > codegeex_13b.tar.gz
-tar xvf codegeex_13b.tar.gz
+cat codegeex_13b.tar.gz.* | tar zxvf -
 ```
 
 ### Inference on GPUs


### PR DESCRIPTION
It's not necessary to write the concatenated tar file to disk just to read it again for extraction. Piping to tar directly is faster and saves significant disk space.